### PR TITLE
updated faker seeds to contain two versions of local images

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,20 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
-100.times do
-  Game.create!(title: Faker::Game.title, description: Faker::Lorem.sentence, review_scores: Faker::Number.between(from: 1, to: 100))
- end
+# frozen_string_literal: true
+
+10.times do
+  Game.create!(
+    title: Faker::Game.title,
+    description: Faker::Lorem.sentence,
+    review_scores: Faker::Number.between(from: 1, to: 100),
+    main_image: File.open(Rails.root.join('db/images/mario_wonder.jpeg'))
+)
+
+end
+
+10.times do
+  Game.create!(
+    title: Faker::Game.title,
+    description: Faker::Lorem.sentence,
+    review_scores: Faker::Number.between(from: 1, to: 100),
+    main_image: File.open(Rails.root.join('db/images/mario_strikers.jpeg'))
+)
+end


### PR DESCRIPTION
Faker seeds now have working images via code and images added to the app locally in db/images. Both images appear for various seeded games however there does not seem to be any order in which they appear, very random currently, this will need to be worked on.